### PR TITLE
add error checking for aws config parameters

### DIFF
--- a/dataactcore/config.py
+++ b/dataactcore/config.py
@@ -20,7 +20,7 @@ CONFIG_LOGGING = CONFIG_ALL['logging']
 CONFIG_JOB_QUEUE = CONFIG_ALL['job-queue']
 
 # for backward-compatibility, differentiate between local runs and AWS
-if CONFIG_BROKER['use_aws'] or CONFIG_BROKER['use_aws'] == "true":
+if CONFIG_BROKER['use_aws'] is True or CONFIG_BROKER['use_aws'] == "true":
     CONFIG_BROKER['local'] = False
     CONFIG_BROKER['broker_files'] = None
     # AWS flag is on, so make sure all needed AWS info is present

--- a/dataactcore/config.py
+++ b/dataactcore/config.py
@@ -23,6 +23,18 @@ CONFIG_JOB_QUEUE = CONFIG_ALL['job-queue']
 if CONFIG_BROKER['use_aws'] or CONFIG_BROKER['use_aws'] == "true":
     CONFIG_BROKER['local'] = False
     CONFIG_BROKER['broker_files'] = None
+    # AWS flag is on, so make sure all needed AWS info is present
+    required_aws_keys = ['aws_access_key_id', 'aws_bucket',
+        'aws_role', 'aws_region', 'aws_create_temp_credentials']
+    for k in required_aws_keys:
+        try:
+            CONFIG_BROKER[k]
+        except KeyError as e:
+            raise KeyError('Config error: use_aws is True, but the {} key is'
+                ' missing from the config.yml file'.format(k))
+        if not CONFIG_BROKER[k]:
+            raise ValueError('Config error: use_aws is True but {} value is '
+                 'missing'.format(k))
 else:
     CONFIG_BROKER['local'] = True
     CONFIG_BROKER['aws_bucket'] = None

--- a/dataactcore/config.py
+++ b/dataactcore/config.py
@@ -40,6 +40,7 @@ else:
     CONFIG_BROKER['aws_bucket'] = None
     CONFIG_BROKER['aws_role'] = None
     CONFIG_BROKER['aws_create_temp_credentials'] = None
+    CONFIG_BROKER['aws_region'] = None
 
     # if not using AWS and no broker file path specified,
     # default to `data_act_broker` in user's home dir


### PR DESCRIPTION
Make sure aws parameters are present in config.yml when use_aws is true. Will post a note in #development that this will break anyone who's missing some of the new-ish aws parameters.