### PR TITLE
fix target metadata assignment

### DIFF
--- a/dataactcore/migrations/env.py
+++ b/dataactcore/migrations/env.py
@@ -44,7 +44,7 @@ config.set_main_option('databases', db_names)
 #       'engine1':mymodel.metadata1,
 #       'engine2':mymodel.metadata2
 #}
-target_metadata = {value[0]: value[1] for (key, value) in db_dict.items()}
+target_metadata = {value[0]: value[1].Base.metadata for (key, value) in db_dict.items()}
 
 # Set up database URLs based on credentials file
 username = str(CONFIG_DB['username'])


### PR DESCRIPTION
Earlier change was missing the `Base.metadata` part of the target_metadata assignment. It was still working (?) but would prefer to match the Alembic instructions and our previous code.