### PR TITLE
Db 376 database simplification

### DIFF
--- a/dataactcore/alembic.ini
+++ b/dataactcore/alembic.ini
@@ -29,7 +29,10 @@ script_location = migrations
 # are written from script.py.mako
 # output_encoding = utf-8
 
-# databases = error_data, job_tracker, user_manager
+# list of database names to target in the migration. set to the complete
+# list of broker backend db names. individual db creation scripts
+# overwrite this setting as necessary
+databases = error_data, job_tracker, user_manager
 
 # [error_data]
 # sqlalchemy.url = ''

--- a/dataactcore/config.py
+++ b/dataactcore/config.py
@@ -5,6 +5,9 @@ import re
 
 # set the location of the DATA Act broker config file
 CONFIG_PATH = os.path.join(dirname(__file__), 'config.yml')
+# set the location of the Alembic config file
+ALEMBIC_PATH = os.path.join(dirname(__file__), 'alembic.ini')
+MIGRATION_PATH = os.path.join(dirname(__file__), 'migrations')
 
 try:
     with open(CONFIG_PATH) as c:

--- a/dataactcore/migrations/env.py
+++ b/dataactcore/migrations/env.py
@@ -1,5 +1,4 @@
 from __future__ import with_statement
-
 from alembic import context
 from dataactcore.models import errorModels
 from dataactcore.models import jobModels
@@ -30,8 +29,13 @@ db_dict['error_data'] = [CONFIG_DB['error_db_name'], errorModels]
 db_dict['job_tracker'] = [CONFIG_DB['job_db_name'], jobModels]
 db_dict['user_manager'] = [CONFIG_DB['user_db_name'], userModel]
 # TODO: add validation db to the list once the backend repos are merged
-db_names = ', '.join([value[0] for (key, value) in db_dict.items()])
-config.set_main_option('databases', db_names)
+db_names = config.get_main_option('databases')
+for name in re.split(r',\s*', db_names):
+    if name not in db_dict:
+        raise Exception('The alembic.ini databases section is targeting '
+                        'a database ({}) that is not set up in env.py. '
+                        'Please add {} info to db_dict in env.py'.
+                        format(name, name))
 
 # add your model's MetaData objects here
 # for 'autogenerate' support.  These must be set
@@ -46,7 +50,7 @@ config.set_main_option('databases', db_names)
 #}
 target_metadata = {value[0]: value[1] for (key, value) in db_dict.items()}
 
-# Set up database URLs based on credentials file
+# Set up database URLs based on config file
 username = str(CONFIG_DB['username'])
 password = str(CONFIG_DB['password'])
 host = str(CONFIG_DB['host'])

--- a/dataactcore/scripts/databaseSetup.py
+++ b/dataactcore/scripts/databaseSetup.py
@@ -1,5 +1,9 @@
 import sqlalchemy_utils
-from dataactcore.config import CONFIG_DB
+from dataactcore.config import CONFIG_DB, ALEMBIC_PATH, MIGRATION_PATH
+from alembic.config import Config
+from alembic import command
+from sqlalchemy.exc import ProgrammingError
+
 
 def createDatabase(dbName):
     """Create specified database if it doesn't exist."""
@@ -11,6 +15,7 @@ def createDatabase(dbName):
     if not sqlalchemy_utils.database_exists(connectString):
         sqlalchemy_utils.create_database(connectString)
 
+
 def dropDatabase(dbName):
     """Drop specified database."""
     config = CONFIG_DB
@@ -18,3 +23,21 @@ def dropDatabase(dbName):
         config["password"], config["host"], config["port"], dbName)
     if sqlalchemy_utils.database_exists(connectString):
         sqlalchemy_utils.drop_database(connectString)
+
+
+def runMigrations(alembicDbName):
+    """Run Alembic migrations for a specific database/model set.
+
+    Args:
+        alembicDbName: the database to target (must match one of the
+        default databases in alembic.ini.
+    """
+    alembic_cfg = Config(ALEMBIC_PATH)
+    alembic_cfg.set_main_option("script_location", MIGRATION_PATH)
+    alembic_cfg.set_main_option("databases", alembicDbName)
+    try:
+        command.upgrade(alembic_cfg, "head")
+    except ProgrammingError as e:
+        if "relation" and "already exists" in e.message:
+            raise Exception("Cannot run initial db migration if tables "
+                            "already exist. " + e.message)

--- a/dataactcore/scripts/recreateDB.py
+++ b/dataactcore/scripts/recreateDB.py
@@ -1,0 +1,32 @@
+import types
+from dataactcore.scripts.databaseSetup import dropDatabase
+from dataactcore.scripts.setupErrorDB import setupErrorDB
+from dataactcore.scripts.setupUserDB import setupUserDB
+from dataactcore.scripts.setupJobTrackerDB import setupJobTrackerDB
+import dataactcore.config
+
+def recreate(dbList):
+    """Drop and re-init specific databases. If dbList is 'all', do everything."""
+    if dbList == 'all':
+        list = []
+        # get list of databases to recreate based on current config settings
+        list.append(dataactcore.config.CONFIG_DB['user_db_name'])
+        list.append(dataactcore.config.CONFIG_DB['job_db_name'])
+        list.append(dataactcore.config.CONFIG_DB['error_db_name'])
+        # TODO: add validator after the repo merge
+    else:
+        # TODO: if this script gets used a lot, put in some error-checking
+        list = dbList
+
+    for db in list:
+        print ('Recreating {}'.format(db))
+        dropDatabase(db)
+        if 'error' in db:
+            dataactcore.config.CONFIG_DB['error_db_name'] = db
+            setupErrorDB()
+        if 'user' in db:
+            dataactcore.config.CONFIG_DB['user_db_name'] = db
+            setupUserDB()
+        if 'job' in db:
+            dataactcore.config.CONFIG_DB['job_db_name'] = db
+            setupJobTrackerDB()

--- a/dataactcore/scripts/setupAllDB.py
+++ b/dataactcore/scripts/setupAllDB.py
@@ -4,9 +4,9 @@ from dataactcore.scripts.setupUserDB import setupUserDB
 
 def setupAllDB():
     """Sets up all databases"""
-    setupJobTrackerDB(hardReset=True)
-    setupErrorDB(True)
-    setupUserDB(True)
+    setupJobTrackerDB()
+    setupErrorDB()
+    setupUserDB()
     
 if __name__ == '__main__':
     setupAllDB()

--- a/dataactcore/scripts/setupErrorDB.py
+++ b/dataactcore/scripts/setupErrorDB.py
@@ -1,20 +1,14 @@
-from dataactcore.models import errorModels
 from dataactcore.models.errorModels import Status, ErrorType
 from dataactcore.models.errorInterface import ErrorInterface
-from dataactcore.scripts.databaseSetup import createDatabase
+from dataactcore.scripts.databaseSetup import createDatabase, runMigrations
 from dataactcore.config import CONFIG_DB
 
 
 def setupErrorDB(hardReset = False):
     """Create job tracker tables from model metadata."""
     createDatabase(CONFIG_DB['error_db_name'])
+    runMigrations('error_data')
     errorDb = ErrorInterface()
-    if hardReset:
-        errorModels.Base.metadata.drop_all(errorDb.engine)
-    errorModels.Base.metadata.create_all(errorDb.engine)
-
-    errorDb.session.commit()
-    errorDb.session.close()
 
     # TODO: define these codes as enums in the data model?
     # insert status types
@@ -43,4 +37,4 @@ def setupErrorDB(hardReset = False):
     errorDb.session.close()
 
 if __name__ == '__main__':
-    setupErrorDB(True)
+    setupErrorDB(False)

--- a/dataactcore/scripts/setupErrorDB.py
+++ b/dataactcore/scripts/setupErrorDB.py
@@ -8,6 +8,10 @@ def setupErrorDB():
     """Create job tracker tables from model metadata."""
     createDatabase(CONFIG_DB['error_db_name'])
     runMigrations('error_data')
+    insertCodes()
+
+def insertCodes():
+    """Insert static data."""
     errorDb = ErrorInterface()
 
     # TODO: define these codes as enums in the data model?

--- a/dataactcore/scripts/setupErrorDB.py
+++ b/dataactcore/scripts/setupErrorDB.py
@@ -4,7 +4,7 @@ from dataactcore.scripts.databaseSetup import createDatabase, runMigrations
 from dataactcore.config import CONFIG_DB
 
 
-def setupErrorDB(hardReset = False):
+def setupErrorDB():
     """Create job tracker tables from model metadata."""
     createDatabase(CONFIG_DB['error_db_name'])
     runMigrations('error_data')
@@ -37,4 +37,4 @@ def setupErrorDB(hardReset = False):
     errorDb.session.close()
 
 if __name__ == '__main__':
-    setupErrorDB(False)
+    setupErrorDB()

--- a/dataactcore/scripts/setupJobTrackerDB.py
+++ b/dataactcore/scripts/setupJobTrackerDB.py
@@ -8,6 +8,11 @@ def setupJobTrackerDB():
     """Create job tracker tables from model metadata."""
     createDatabase(CONFIG_DB['job_db_name'])
     runMigrations('job_tracker')
+    insertCodes()
+
+
+def insertCodes():
+    """Create job tracker tables from model metadata."""
     jobDb = JobTrackerInterface()
 
     # TODO: define these codes as enums in the data model?

--- a/dataactcore/scripts/setupJobTrackerDB.py
+++ b/dataactcore/scripts/setupJobTrackerDB.py
@@ -1,23 +1,16 @@
-from dataactcore.models import jobModels
 from dataactcore.models.jobModels import Status, Type, FileType
 from dataactcore.models.jobTrackerInterface import JobTrackerInterface
-from dataactcore.scripts.databaseSetup import createDatabase
+from dataactcore.scripts.databaseSetup import createDatabase, runMigrations
 from dataactcore.config import CONFIG_DB
 
 
 def setupJobTrackerDB(hardReset = False):
     """Create job tracker tables from model metadata."""
     createDatabase(CONFIG_DB['job_db_name'])
+    runMigrations('job_tracker')
     jobDb = JobTrackerInterface()
-    if hardReset:
-        jobModels.Base.metadata.drop_all(jobDb.engine)
-    jobModels.Base.metadata.create_all(jobDb.engine)
-
-    jobDb.session.commit()
-    jobDb.session.close()
 
     # TODO: define these codes as enums in the data model?
-
     # insert status types
     statusList = [(1, 'waiting', 'check dependency table'),
         (2, 'ready', 'can be assigned'),

--- a/dataactcore/scripts/setupJobTrackerDB.py
+++ b/dataactcore/scripts/setupJobTrackerDB.py
@@ -4,7 +4,7 @@ from dataactcore.scripts.databaseSetup import createDatabase, runMigrations
 from dataactcore.config import CONFIG_DB
 
 
-def setupJobTrackerDB(hardReset = False):
+def setupJobTrackerDB():
     """Create job tracker tables from model metadata."""
     createDatabase(CONFIG_DB['job_db_name'])
     runMigrations('job_tracker')
@@ -43,4 +43,4 @@ def setupJobTrackerDB(hardReset = False):
     jobDb.session.close()
 
 if __name__ == '__main__':
-    setupJobTrackerDB(hardReset=True)
+    setupJobTrackerDB()

--- a/dataactcore/scripts/setupUserDB.py
+++ b/dataactcore/scripts/setupUserDB.py
@@ -1,22 +1,16 @@
-from dataactcore.models import userModel
 from dataactcore.models.userModel import PermissionType, UserStatus
 from dataactcore.models.userInterface import UserInterface
-from dataactcore.scripts.databaseSetup import createDatabase
+from dataactcore.scripts.databaseSetup import createDatabase, runMigrations
 from dataactcore.config import CONFIG_DB
+
 
 def setupUserDB(hardReset = False):
     """Create user tables from model metadata."""
     createDatabase(CONFIG_DB['user_db_name'])
+    runMigrations('user_manager')
     userDb = UserInterface()
-    if hardReset:
-        userModel.Base.metadata.drop_all(userDb.engine)
-    userModel.Base.metadata.create_all(userDb.engine)
-
-    userDb.session.commit()
-    userDb.session.close()
 
     # TODO: define these codes as enums in the data model?
-
     # insert status types
     statusList = [(1, 'awaiting_confirmation', 'User has entered email but not confirmed'),
         (2, 'email_confirmed', 'User email has been confirmed'),

--- a/dataactcore/scripts/setupUserDB.py
+++ b/dataactcore/scripts/setupUserDB.py
@@ -4,7 +4,7 @@ from dataactcore.scripts.databaseSetup import createDatabase, runMigrations
 from dataactcore.config import CONFIG_DB
 
 
-def setupUserDB(hardReset = False):
+def setupUserDB():
     """Create user tables from model metadata."""
     createDatabase(CONFIG_DB['user_db_name'])
     runMigrations('user_manager')
@@ -33,4 +33,4 @@ def setupUserDB(hardReset = False):
     userDb.session.close()
 
 if __name__ == '__main__':
-    setupUserDB(hardReset=True)
+    setupUserDB()

--- a/dataactcore/scripts/setupUserDB.py
+++ b/dataactcore/scripts/setupUserDB.py
@@ -8,6 +8,11 @@ def setupUserDB():
     """Create user tables from model metadata."""
     createDatabase(CONFIG_DB['user_db_name'])
     runMigrations('user_manager')
+    insertCodes()
+
+
+def insertCodes():
+    """Create job tracker tables from model metadata."""
     userDb = UserInterface()
 
     # TODO: define these codes as enums in the data model?


### PR DESCRIPTION
This PR is for [DB-376](https://federal-spending-transparency.atlassian.net/browse/DB-376):

* Default alembic.ini database list to the complete set of dbs (validation to be added post-repo merge)
* Instead of setting the target database list, env.py will read it from alembic.ini and process accordingly
* As a result, you can programmatically target migrations to a subset of the database as needed (e.g., the db init scripts)
* In the db init scripts:

        * remove SQL Alchemy table drop/create logic in favor of running Alembic migrations:
        * remove hardReset option
* Add a simple script for dropping and recreating a list of databases
